### PR TITLE
iphlpapi depends on iphlpapi.lib/iphlpapi.a

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -197,7 +197,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("ioapiset", &["basetsd", "minwinbase", "minwindef", "winnt"], &["kernel32"]),
     ("ipexport", &["basetsd", "in6addr", "ntdef"], &[]),
     ("iphlpapi", &["basetsd", "ifmib", "ipexport", "ipmib", "iprtrmib", "iptypes", "minwinbase", "minwindef", "ntdef", "tcpmib", "udpmib", "ws2def", "ws2ipdef"], &[]),
-    ("iptypes", &["basetsd", "guiddef", "ifdef", "ipifcons", "minwindef", "nldef", "ntdef", "ws2def"], &[]),
+    ("iptypes", &["basetsd", "guiddef", "ifdef", "ipifcons", "minwindef", "nldef", "ntdef", "ws2def"], &["iphlpapi"]),
     ("jobapi", &["minwindef", "winnt"], &["kernel32"]),
     ("jobapi2", &["basetsd", "minwinbase", "minwindef", "ntdef", "winnt"], &["kernel32"]),
     ("knownfolders", &[], &[]),


### PR DESCRIPTION
```toml
[package]
name = "foo"
version = "0.0.0"
edition = "2018"

[dependencies.winapi]
git = "https://github.com/delan/winapi-rs"
rev = "b8aa9b511914a3b4b92cced4bdd87429cd91668a"
features = ["iphlpapi", "winerror"]
```

```rust
use winapi::shared::winerror::ERROR_BUFFER_OVERFLOW;
use winapi::um::iptypes::FIXED_INFO;
use winapi::um::iphlpapi::GetNetworkParams;

fn main() {
    unsafe {
        assert_eq!(GetNetworkParams(Vec::new().as_mut_ptr(), &mut 0), ERROR_BUFFER_OVERFLOW);
    }
}
```